### PR TITLE
fix: Ensure restart button works during nuke explosion

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -198,7 +198,7 @@ while running:
                         shield_timer = shield_duration
                         shield_charges -= 1
             if game_state == "game_over":
-                if event.key == pygame.K_r and not explosion_active:
+                if event.key == pygame.K_r:
                     reset_game()
                     game_state = "playing"
 


### PR DESCRIPTION
This commit fixes a bug that prevented you from restarting the game if the game ended with a nuke explosion. The condition that blocked the restart during the explosion animation has been removed, allowing you to restart at any point on the game over screen.